### PR TITLE
changed default compression level for png images from 9 to 4

### DIFF
--- a/pipelime/filesystem/toolkit.py
+++ b/pipelime/filesystem/toolkit.py
@@ -12,6 +12,11 @@ from collections import defaultdict
 
 class FSToolkit(object):
 
+    # Default imageio options for each image format
+    OPTIONS = {
+        'png': {'compress_level': 4},
+    }
+
     # Declare TREE structure
     @classmethod
     def tree(cls):
@@ -133,11 +138,10 @@ class FSToolkit(object):
 
     @classmethod
     def store_data(cls, filename: str, data: any):
-
         extension = cls.get_file_extension(filename)
-
         if DataCoding.is_image_extension(extension):
-            imageio.imwrite(filename, data)
+            options = cls.OPTIONS.get(extension, {})
+            imageio.imwrite(filename, data, **options)
         elif DataCoding.is_text_extension(extension):
             np.savetxt(filename, data)
         elif DataCoding.is_numpy_extension(extension):


### PR DESCRIPTION
Added a class member `OPTIONS` in `FSToolkIt` containing imageio default overrides for each image format.

Compression level for png images is set to 4 instead of 9 (imageio default).