### PR TITLE
Added SplitByValue operation, similar to GroupBy without complex Grou…

### DIFF
--- a/pipelime/cli/underfolder/underfolder.py
+++ b/pipelime/cli/underfolder/underfolder.py
@@ -9,6 +9,7 @@ from pipelime.cli.underfolder.operations import operation_splitbyquery
 from pipelime.cli.underfolder.operations import operation_filterbyscript
 from pipelime.cli.underfolder.operations import operation_filterkeys
 from pipelime.cli.underfolder.operations import operation_orderby
+from pipelime.cli.underfolder.operations import operation_split_by_value
 from pipelime.cli.underfolder.operations import operation_groupby
 
 
@@ -26,4 +27,5 @@ underfolder.add_command(operation_splitbyquery)
 underfolder.add_command(operation_filterbyscript)
 underfolder.add_command(operation_filterkeys)
 underfolder.add_command(operation_orderby)
+underfolder.add_command(operation_split_by_value)
 underfolder.add_command(operation_groupby)

--- a/tests/pipelime/cli/underfolder.py
+++ b/tests/pipelime/cli/underfolder.py
@@ -302,6 +302,42 @@ class TestCLIUnderfolderOperationOrderKeys:
         assert output_reader[0]['label'] == 9  # The first sample should be `9`! CHeck it!!
 
 
+class TestCLIUnderfolderOperationSplitByValue:
+
+    def test_split_by_value(self, tmpdir, sample_underfolder_minimnist):
+
+        from pipelime.cli.underfolder.operations import operation_split_by_value
+        from pathlib import Path
+        import uuid
+
+        input_folder = sample_underfolder_minimnist['folder']
+        input_dataset = UnderfolderReader(folder=input_folder)
+
+        # script
+        split_key = 'metadata.sample_id'
+
+        output_folder = Path(tmpdir.mkdir(str(uuid.uuid1())))
+        print("OUTPUT", output_folder)
+
+        options = []
+        options.extend(['-i', str(input_folder)])
+        options.extend(['-k', f'{str(split_key)}'])
+        options.extend(['-o', f'{str(output_folder)}'])
+
+        runner = CliRunner()
+        result = runner.invoke(operation_split_by_value, options)
+        print(result)
+
+        assert result.exit_code == 0
+
+        total = 0
+        for subfolder in output_folder.iterdir():
+            print(subfolder)
+            output_reader = UnderfolderReader(folder=subfolder)
+            total += len(output_reader)
+        assert total == len(input_dataset)
+
+
 class TestCLIUnderfolderOperationGroupBy:
 
     def test_groupby(self, tmpdir, sample_underfolder_minimnist):

--- a/tests/pipelime/sequences/test_operations.py
+++ b/tests/pipelime/sequences/test_operations.py
@@ -9,7 +9,7 @@ from pipelime.sequences.samples import SamplesSequence
 from pipelime.sequences.operations import (
     OperationDict2List, OperationFilterByQuery, OperationFilterByScript, OperationFilterKeys, OperationGroupBy,
     OperationIdentity, OperationOrderBy, OperationPort, OperationResetIndices, OperationShuffle,
-    OperationSplitByQuery, OperationSplits, OperationSubsample,
+    OperationSplitByQuery, OperationSplitByValue, OperationSplits, OperationSubsample,
     OperationSum, SequenceOperation
 )
 
@@ -359,6 +359,26 @@ class TestOperationSplitByQuery(object):
             sumup_exp = functools.reduce(lambda a, b: a + b, expecteds)
 
             assert sumup == sumup_exp
+
+
+class TestOperationSplitByValue:
+    def test_split_by_value(self, plain_samples_sequence_generator):
+        N = 20
+        G = 5
+        key = "metadata.deep.groupby_field"
+        dataset = plain_samples_sequence_generator("d0_", N, group_each=G)
+        op = OperationSplitByValue(key)
+        _plug_test(op)
+        out = op(dataset)
+
+        assert len(out) == N // G
+        total = 0
+        for split in out:
+            total += len(split)
+            target = pydash.get(split[0], key)
+            for sample in split:
+                assert pydash.get(sample, key) == target
+        assert total == len(dataset)
 
 
 class TestOperationFilterKeys(object):


### PR DESCRIPTION
- Added option to convert root files into regular items when performing an underfolder sum
- Added operation **split by value**, similar to **group by**, but instead of returning a single dataset with grouped samples, it simply splits the input dataset into N regular ones. 