### PR TITLE
Added reader summaries

### DIFF
--- a/pipelime/cli/h5/h5.py
+++ b/pipelime/cli/h5/h5.py
@@ -1,0 +1,11 @@
+import click
+
+from pipelime.cli.h5.operations import summary
+
+
+@click.group()
+def h5():
+    pass
+
+
+h5.add_command(summary)

--- a/pipelime/cli/h5/operations.py
+++ b/pipelime/cli/h5/operations.py
@@ -1,0 +1,16 @@
+import click
+from pathlib import Path
+
+@click.command("summary", help="Prints the summary of a h5 dataset")
+@click.option("-i", "--input", "path", type=Path, required=True, help="Input dataset")
+@click.option("-o", "--order_by", type=click.Choice(["name", "root_item", "count", "encoding", "typeinfo"]), default="name", help="Sort by column value")
+@click.option("-R", "--reversed", "reversed_", is_flag=True, help="Reverse sorting")
+@click.option("-k", "--max_samples", default=3, type=int, help="Maximum number of samples to read from the dataset")
+def summary(path, order_by, reversed_, max_samples):
+
+    from pipelime.sequences.readers.h5 import H5Reader
+    from pipelime.cli.summary import print_summary
+
+    reader = H5Reader(path)
+    print_summary(reader, order_by=order_by, reversed_=reversed_, max_samples=max_samples)
+

--- a/pipelime/cli/main.py
+++ b/pipelime/cli/main.py
@@ -2,8 +2,9 @@ import click
 
 from pipelime.cli.datasets.datasets import datasets
 from pipelime.cli.workflow.workflow import workflow
-from pipelime.cli.underfolder.underfolder import underfolder
 from pipelime.cli.conversions.conversions import conversions
+from pipelime.cli.underfolder.underfolder import underfolder
+from pipelime.cli.h5.h5 import h5
 
 
 @click.group()
@@ -13,5 +14,6 @@ def pipelime():
 
 pipelime.add_command(datasets)
 pipelime.add_command(workflow)
-pipelime.add_command(underfolder)
 pipelime.add_command(conversions)
+pipelime.add_command(underfolder)
+pipelime.add_command(h5)

--- a/pipelime/cli/summary.py
+++ b/pipelime/cli/summary.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from pipelime.sequences.readers.base import BaseReader
+from pipelime.sequences.readers.filesystem import UnderfolderReader
+from pipelime.sequences.readers.h5 import H5Reader
+from pipelime.sequences.readers.summary import ItemInfo, ReaderSummary, TypeInfo
+from pipelime.sequences.samples import SamplesSequence
+from pipelime.tools.bytes import DataCoding
+
+
+class SummaryPrinter:
+    TITLE_STYLE = "bold bright_blue"
+    ENC_CAT_STYLE_MAP = {
+        "image": "bold magenta",
+        "numpy": "bold cyan",
+        "markup": "bold yellow",
+        "pickle": "bold red",
+    }
+    ENC_CAT_MAP = {
+        "image": DataCoding.IMAGE_CODECS,
+        "numpy": DataCoding.NUMPY_CODECS + DataCoding.TEXT_CODECS,
+        "markup": DataCoding.METADATA_CODECS,
+        "pickle": DataCoding.PICKLE_CODECS,
+    }
+    ENC_STYLE_MAP = {}
+    for c in ENC_CAT_MAP:
+        for codec in ENC_CAT_MAP[c]:
+            ENC_STYLE_MAP[codec] = ENC_CAT_STYLE_MAP[c]
+    ITEM_NAME_STYLE = "bold blue"
+    TYPE_NAME_STYLE = "bold green"
+    DTYPE_STYLE = "green"
+    SHAPE_STYLE = "yellow"
+    BOOL_TRUE_STYLE = "bold green"
+    BOOL_FALSE_STYLE = "bold red"
+
+    def repr_name(self, name: str) -> str:
+        return f"[{self.ITEM_NAME_STYLE}]{name}[/{self.ITEM_NAME_STYLE}]"
+
+    def repr_typeinfo(self, t: TypeInfo) -> str:
+        style = self.TYPE_NAME_STYLE
+        typenames = [f"[{style}]{x.__name__}[/{style}]" for x in t.types]
+        str_ = " | ".join(typenames)
+        if t.dtype is not None:
+            str_ += f" [{self.DTYPE_STYLE}]{t.dtype}[/{self.DTYPE_STYLE}]"
+        if t.shape is not None:
+            style = self.SHAPE_STYLE
+            formatted_shape = [f"[{style}]{x}[/{style}]" for x in t.shape]
+            str_ += " [" + " × ".join(formatted_shape) + "]"
+        return str_
+
+    def repr_count(self, c: int, total: int) -> str:
+        style = self.BOOL_TRUE_STYLE if c == total else self.BOOL_FALSE_STYLE
+        return f"[{style}]{c}/{total}[/{style}]"
+
+    def repr_bool(self, val: bool) -> str:
+        style = self.BOOL_TRUE_STYLE if val else self.BOOL_FALSE_STYLE
+        return f"[{style}]{val}[/{style}]"
+
+    def repr_encoding(self, enc: str) -> str:
+        if enc not in self.ENC_STYLE_MAP:
+            return "Unknown"
+        style = self.ENC_STYLE_MAP[enc]
+        return f"[{style}]{enc}[/{style}]"
+
+    def repr_iteminfo(self, seq: SamplesSequence, iteminfo: ItemInfo) -> str:
+        repr_name_ = self.repr_name(iteminfo.name)
+        repr_typeinfo_ = self.repr_typeinfo(iteminfo.typeinfo)
+        repr_count_ = self.repr_count(iteminfo.count, len(seq))
+        repr_is_root_ = self.repr_bool(iteminfo.root_item)
+        repr_encoding_ = self.repr_encoding(iteminfo.encoding)
+        return repr_name_, repr_count_, repr_typeinfo_, repr_is_root_, repr_encoding_
+
+    def print(self, summary: ReaderSummary) -> None:
+        console = Console()
+        style = self.TITLE_STYLE
+        console.print(f"[{style}]Type[/{style}]: {summary.reader.__class__.__name__}")
+        console.print(f"[{style}]Length[/{style}]: {len(summary.reader)}")
+        console.print()
+        if summary.k > 1:
+            str_ = f"based on first {summary.k} samples"
+        elif summary.k == 1:
+            str_ = "based on first sample"
+        else:
+            str_ = "based on all samples"
+        console.print(f"[{style}]Contents[/{style}] \[{str_}]:")
+
+        table = Table(header_style=self.TITLE_STYLE)
+        table.add_column("Item Name")
+        table.add_column("Count")
+        table.add_column("Item Type")
+        table.add_column("Is Root Item")
+        table.add_column("Encoding")
+
+        for iteminfo in summary:
+            repr_iteminfo_ = self.repr_iteminfo(summary.reader, iteminfo)
+            table.add_row(*repr_iteminfo_)
+
+        console.print(table)
+        pass
+
+
+def print_summary(
+    reader: BaseReader,
+    max_samples: int = 3,
+    order_by: str = "name",
+    reversed_: bool = False,
+) -> None:
+    summary = ReaderSummary(reader, k=max_samples)
+    summary.sort(key=order_by, reverse=reversed_)
+    SummaryPrinter().print(summary)

--- a/pipelime/cli/underfolder/operations.py
+++ b/pipelime/cli/underfolder/operations.py
@@ -354,6 +354,19 @@ def operation_groupby(input_folder, key, output_folder):
     )
     writer(output_dataset)
 
+@click.command("summary", help="Prints the summary of an underfolder dataset")
+@click.option("-i", "--input", "path", type=Path, required=True, help="Input dataset")
+@click.option("-o", "--order_by", type=click.Choice(["name", "root_item", "count", "encoding", "typeinfo"]), default="name", help="Sort by column value")
+@click.option("-R", "--reversed", "reversed_", is_flag=True, help="Reverse sorting")
+@click.option("-k", "--max_samples", default=3, type=int, help="Maximum number of samples to read from the dataset")
+def summary(path, order_by, reversed_, max_samples):
+
+    from pipelime.sequences.readers.filesystem import UnderfolderReader
+    from pipelime.cli.summary import print_summary
+
+    reader = UnderfolderReader(path)
+    print_summary(reader, order_by=order_by, reversed_=reversed_, max_samples=max_samples)
+
 
 if __name__ == '__main__':
     operation_filterbyquery()

--- a/pipelime/cli/underfolder/underfolder.py
+++ b/pipelime/cli/underfolder/underfolder.py
@@ -12,6 +12,7 @@ from pipelime.cli.underfolder.operations import operation_orderby
 from pipelime.cli.underfolder.operations import operation_split_by_value
 from pipelime.cli.underfolder.operations import operation_groupby
 from pipelime.cli.underfolder.operations import operation_mix
+from pipelime.cli.underfolder.operations import summary
 
 
 @click.group()
@@ -31,3 +32,4 @@ underfolder.add_command(operation_orderby)
 underfolder.add_command(operation_split_by_value)
 underfolder.add_command(operation_groupby)
 underfolder.add_command(operation_mix)
+underfolder.add_command(summary)

--- a/pipelime/sequences/readers/summary.py
+++ b/pipelime/sequences/readers/summary.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+from pipelime.sequences.samples import SamplesSequence
+
+from typing import Any, Iterable, Sequence, Type
+
+import numpy as np
+
+from pipelime.sequences.readers.base import BaseReader
+
+
+class ItemInfo:
+    """Holds information on an Item"""
+
+    def __init__(
+        self,
+        name: str,
+        typeinfo: TypeInfo,
+        count: int,
+        root_item: bool,
+        encoding: str,
+    ) -> None:
+        self.name = name
+        self.typeinfo = typeinfo
+        self.count = count
+        self.root_item = root_item
+        self.encoding = encoding
+
+
+class TypeInfo:
+    """Wraps the type of an Item, and handles the common properties of
+    array-like types, such as shape and dtype.
+    """
+
+    def __init__(
+        self,
+        *types: Iterable[Type],
+        shape: Iterable[int] = None,
+        dtype: Any = None,
+    ) -> None:
+        self.types = set(types)
+        self.shape = shape
+        self.dtype = dtype
+
+    def __repr__(self) -> str:
+        return str((self.types, self.shape, self.dtype))
+
+    def _merge(self, other: TypeInfo) -> TypeInfo:
+        shape = self._merge_shapes(other)
+        dtype = None
+        if self.dtype == other.dtype:
+            dtype = self.dtype
+        return TypeInfo(*self.types, *other.types, shape=shape, dtype=dtype)
+
+    def _merge_shapes(self, other):
+        if self.shape is None or other.shape is None:
+            return None
+        if len(self.shape) != len(other.shape):
+            return None
+
+        a = np.array(self.shape)
+        b = np.array(other.shape)
+
+        where_eq = a == b
+        final_shape = a * where_eq - 1 * (1 - where_eq)
+        return final_shape.tolist()
+
+    def __add__(self, other: TypeInfo) -> TypeInfo:
+        """Creates a Union TypeInfo 'merging' the information of two
+        TypeInfo objects.
+
+        Output types is the set union of self types and other types
+
+        If both objects have a specified shape with the same length, the
+        output shape is the union shape, None otherwise.
+
+        If both objects have a specified dtype with the same value, the
+        output dtype is self.dtype, None otherwise.
+
+        :param other: another TypeInfo object to merge
+        :type other: TypeInfo
+        :return: the union TypeInfo object
+        :rtype: TypeInfo
+        """
+        return self._merge(other)
+
+
+class ItemInfoFactory:
+    """Provides an easy way to instantiate ItemInfo objects from a pipelime
+    BaseReader object
+    """
+
+    @classmethod
+    def _build_type_info(cls, obj: Any) -> TypeInfo:
+        the_type = type(obj)
+        shape = None
+        dtype = None
+        if hasattr(obj, "shape"):
+            shape = obj.shape
+        if hasattr(obj, "dtype"):
+            dtype = str(obj.dtype)
+        typeinfo = TypeInfo(the_type, shape=shape, dtype=dtype)
+        return typeinfo
+
+    @classmethod
+    def build_item_info(cls, reader: BaseReader, key: str, k: int) -> ItemInfo:
+        """Instantiates an ItemInfo object from the first k items whose key match the input key.
+
+        :param reader: Input pipelime reader
+        :type reader: BaseReader
+        :param key: The query key to inspect
+        :type key: str
+        :param k: The first k samples to inspect, this is done to avoid reading the entire
+        dataset and speedup the summary creation. Set k<1 to inspect every sample.
+        :type k: int
+        :return: An ItemInfo object
+        :rtype: ItemInfo
+        """
+        template = reader.get_reader_template()
+
+        # Count items
+        count = 0
+        for sample in reader:
+            if key in sample:
+                count += 1
+
+        # Get item types
+        if k < 1:
+            k = len(reader)
+        typeinfos = []
+        for i in range(k):
+            sample = reader[i]
+            if key in sample:
+                typeinfo = cls._build_type_info(sample[key])
+                typeinfos.append(typeinfo)
+            if hasattr(sample, "flush"):
+                sample.flush()
+        typeinfo = typeinfos[0]
+        for t in typeinfos:
+            typeinfo += t
+
+        # Is root item?
+        root_item = key in template.root_files_keys
+
+        # Get encoding type
+        encoding = template.extensions_map.get(key)
+
+        return ItemInfo(key, typeinfo, count, root_item, encoding)
+
+    @classmethod
+    def get_all_keys(cls, seq: SamplesSequence) -> Sequence[str]:
+        """Retrieves all items contained in a SamplesSequence.
+
+        :param seq: The sequence to inspect
+        :type seq: SamplesSequence
+        :return: The list of all item keys
+        :rtype: Sequence[str]
+        """
+        all_keys = []
+        for sample in seq:
+            all_keys += list(sample.keys())
+        all_keys = sorted(set(all_keys))
+        return all_keys
+
+    @classmethod
+    def build_all(cls, reader: BaseReader, k: int) -> Sequence[ItemInfo]:
+        """Creates all ItemInfo objects for every item key in an input reader
+
+        :param reader: Input pipelime BaseReader
+        :type reader: BaseReader
+        :param k:
+        :param k: The first k samples to inspect, this is done to avoid reading the entire
+        dataset and speedup the summary creation. Set k<1 to inspect every sample.
+        :type k: int
+        :return: The list of all ItemInfos
+        :rtype: Sequence[ItemInfo]
+        """
+        keys = cls.get_all_keys(reader)
+        return [cls.build_item_info(reader, key, k) for key in keys]
+
+
+class ReaderSummary:
+    """Wraps a reader and its corresponding list of iteminfos"""
+
+    def __init__(self, reader: BaseReader, k: int = 3) -> None:
+        self.k = min(k, len(reader))
+        self.reader = reader
+        self._iteminfos = ItemInfoFactory.build_all(self.reader, self.k)
+
+    def sort(self, key: str = "name", reverse: bool = False) -> None:
+        """Internally sorts the iteminfo list according to a specified key
+
+        :param key: the key along which to sort, defaults to "name"
+        :type key: str, optional
+        :param reverse: reverse sorting, defaults to False
+        :type reverse: bool, optional
+        """
+        self._iteminfos = sorted(
+            self._iteminfos, key=lambda x: str(getattr(x, key)), reverse=reverse
+        )
+
+    def __getitem__(self, k: int) -> ItemInfo:
+        return self._iteminfos[k]
+
+    def __len__(self) -> int:
+        return len(self._iteminfos)

--- a/tests/pipelime/sequences/io/test_summary.py
+++ b/tests/pipelime/sequences/io/test_summary.py
@@ -1,0 +1,65 @@
+from pipelime.sequences.readers.filesystem import UnderfolderReader
+from pipelime.sequences.readers.summary import ReaderSummary, TypeInfo
+import numpy as np
+
+class TestSummary:
+    def test_summary(self, toy_dataset_small):
+        path = toy_dataset_small["folder"]
+        non_root = toy_dataset_small["expected_keys"]
+        root_keys = toy_dataset_small["root_keys"]
+        all_keys = [*non_root, *root_keys]
+        reader = UnderfolderReader(path)
+        summary = ReaderSummary(reader, k=-1)
+        summary.sort()
+        assert len(summary) == len(all_keys)
+
+        # Check iteminfo 0
+        iteminfo = summary[0]
+        key = sorted(all_keys)[0]
+        assert iteminfo.name == key
+        assert iteminfo.count == len(reader)
+        assert np.ndarray in iteminfo.typeinfo.types 
+        assert iteminfo.root_item == (key in root_keys)
+        assert iteminfo.encoding == "npy"
+
+class TestTypeInfo:
+    def test_typeinfo(self):
+        # Compatible but different shape
+        a = TypeInfo(np.ndarray, shape=[100, 100, 100], dtype="uint8")
+        b = TypeInfo(np.ndarray, shape=[200, 100, 100], dtype="uint8")
+        c = a + b
+        assert c.types == {np.ndarray}
+        assert c.shape == [-1, 100, 100]
+        assert c.dtype == "uint8"
+
+        # Incompatible shape
+        a = TypeInfo(np.ndarray, shape=[100, 100, 100], dtype="uint8")
+        b = TypeInfo(np.ndarray, shape=[100, 100], dtype="uint8")
+        c = a + b
+        assert c.types == {np.ndarray}
+        assert c.shape == None
+        assert c.dtype == "uint8"
+
+        # None shape
+        a = TypeInfo(np.ndarray, shape=None, dtype="uint8")
+        b = TypeInfo(np.ndarray, shape=[200, 100, 100], dtype="uint8")
+        c = a + b
+        assert c.types == {np.ndarray}
+        assert c.shape == None
+        assert c.dtype == "uint8"
+
+        # Incompatible dtypes
+        a = TypeInfo(np.ndarray, shape=None, dtype="uint16")
+        b = TypeInfo(np.ndarray, shape=None, dtype="uint8")
+        c = a + b
+        assert c.types == {np.ndarray}
+        assert c.shape == None
+        assert c.dtype == None
+
+        # Incompatible types
+        a = TypeInfo(list, shape=None, dtype="uint8")
+        b = TypeInfo(np.ndarray, shape=[200, 100, 100], dtype="uint8")
+        c = a + b
+        assert c.types == {np.ndarray, list}
+        assert c.shape == None
+        assert c.dtype == "uint8"


### PR DESCRIPTION
Added pipelime dataset summaries.

A summary contains info on the items contained in a dataset, such as:
- Item **name**
- Item **count** (number of samples that have that item)
- Item **type** with support for array-like types that have a "shape" and "dtype" attribute
- Whether an **item** is a root item or not 
- The item **encoding**

These summaries can be created from any type of pipelime `BaseReader` and can be rich-printed with a custom class `SummaryPrinter`.

You can print a summary from the CLI with the following command:

```bash
pipelime $READERTYPE summary -i $PATH [-o $ORDERBY] [--reversed] [-k $MAXSAMPLES] 
```
Where:
- `$READERTYPE` is the seletion between currently supported reader types, `underfolder` and `h5`
- `$PATH` is the input dataset path
- `$ORDERBY` is the sorting key (`name` by default)
- `$MAXSAMPLES` is the maximum number of samples to inspect (3 by default, this is done to make things quicker)

Example:
![1c21524f-16a3-406b-ab64-d18afbe0e63e](https://user-images.githubusercontent.com/6567253/134771077-1f8eda44-e129-4984-b581-ab116c0a7a12.png)

