### PR TITLE
Pipelime 27 piper executor that displays progress feedback

### DIFF
--- a/examples/piper/execute/watcher_demo.py
+++ b/examples/piper/execute/watcher_demo.py
@@ -1,111 +1,12 @@
-import threading
-import time
-
 import click
-from pydantic import BaseModel
-import rich
-from rich.live import Live
-from rich.table import Table
 
-from pipelime.pipes.communication import PiperCommunicationChannelFactory
-
-
-def percentage_string(v: float):
-    color = "red"
-    if v > 0.33:
-        color = "yellow"
-    if v > 0.66:
-        color = "green"
-    return f"[{color}]{v*100:.1f}%[/{color}]"
-
-
-def generate_table(tasks_map: dict) -> Table:
-    """Make a new table."""
-    table = Table()
-    table.add_column("File")
-    table.add_column("Method")
-    table.add_column("ID")
-    table.add_column("Progress")
-
-    for task_id in tasks_map.keys():
-        progress = [percentage_string(v) for _, v in tasks_map[task_id].items()]
-        progress = " ‖ ".join(progress)
-
-        filename, method, unique = task_id.split(":")
-        table.add_row(
-            f"{filename}",
-            f"{method}",
-            f"{unique}",
-            f"{progress}",
-        )
-
-    return table
-
-
-class ChunkProgress(BaseModel):
-    id: str
-    chunk_index: int
-    progress: float
-
-    @property
-    def file(self):
-        return self.id.split(":")[0]
-
-    @property
-    def method(self):
-        return self.id.split(":")[1]
-
-    @property
-    def unique(self):
-        return self.id.split(":")[2]
+from pipelime.pipes.watcher import Watcher
 
 
 @click.command("piper_watcher")
 @click.option("-t", "--token", default="", help="Token to use for the piper.")
 def piper_watcher(token: str):
-
-    tasks_map = {}
-
-    def callback(data: dict):
-        if "_progress" in data["payload"]:
-            chunk_progress = ChunkProgress(
-                id=data["id"],
-                chunk_index=data["payload"]["_progress"]["chunk_index"],
-                progress=data["payload"]["_progress"]["progress_data"]["advance"]
-                / data["payload"]["_progress"]["progress_data"]["total"],
-            )
-
-            if chunk_progress.id not in tasks_map:
-                tasks_map[chunk_progress.id] = {}
-            if chunk_progress.chunk_index not in tasks_map[chunk_progress.id]:
-                tasks_map[chunk_progress.id][chunk_progress.chunk_index] = 0.0
-
-            tasks_map[chunk_progress.id][
-                chunk_progress.chunk_index
-            ] += chunk_progress.progress
-        elif "event" in data["payload"]:
-            event = data["payload"]["event"]
-
-            if event not in tasks_map:
-                tasks_map[event] = {0: 0.0}
-
-            tasks_map[event][0] += 1
-
-    def listener_thread():
-        channel = PiperCommunicationChannelFactory.create_channel(token)
-        rich.print(f"Channel class: {channel.__class__}")
-        channel.register_callback(callback)
-        channel.listen()
-
-    thread = threading.Thread(target=listener_thread, daemon=True)
-    thread.start()
-
-    with Live(generate_table(tasks_map), refresh_per_second=4) as live:
-        while True:
-            time.sleep(0.1)
-            live.update(generate_table(tasks_map))
-
-    thread.join()
+    Watcher(token).watch()
 
 
 if __name__ == "__main__":

--- a/examples/piper/execute/watcher_demo.py
+++ b/examples/piper/execute/watcher_demo.py
@@ -1,3 +1,5 @@
+import time
+
 import click
 
 from pipelime.pipes.watcher import Watcher
@@ -7,6 +9,8 @@ from pipelime.pipes.watcher import Watcher
 @click.option("-t", "--token", default="", help="Token to use for the piper.")
 def piper_watcher(token: str):
     Watcher(token).watch()
+    while True:
+        time.sleep(1)
 
 
 if __name__ == "__main__":

--- a/pipelime/cli/piper/piper.py
+++ b/pipelime/cli/piper/piper.py
@@ -180,6 +180,7 @@ def execute(
 
     from pipelime.pipes.executors.base import WatcherNodesGraphExecutor
     from pipelime.pipes.executors.naive import NaiveGraphExecutor
+    from pipelime.pipes.communication import PiperCommunicationChannelFactory
     from pipelime.pipes.graph import DAGNodesGraph
     from pipelime.pipes.parsers.factory import DAGConfigParserFactory
     from pipelime.tools.click import ClickTools
@@ -205,6 +206,8 @@ def execute(
     # Graph
     graph = DAGNodesGraph.build_nodes_graph(dag)
     executor.exec(graph, token=token)
+
+    PiperCommunicationChannelFactory.create_channel(token).close()
 
 
 if __name__ == "__main__":

--- a/pipelime/cli/piper/piper.py
+++ b/pipelime/cli/piper/piper.py
@@ -193,7 +193,7 @@ def execute(
 ):
 
     from pipelime.pipes.parsers.factory import DAGConfigParserFactory
-    from pipelime.pipes.executors.naive import NaiveGraphExecutor
+    from pipelime.pipes.executors.naive import NaiveGraphExecutorAndWatcher
     from pipelime.pipes.graph import DAGNodesGraph
     from pipelime.tools.click import ClickTools
 
@@ -208,7 +208,7 @@ def execute(
     graph = DAGNodesGraph.build_nodes_graph(dag)
 
     if execution_backend == "naive":
-        executor = NaiveGraphExecutor()
+        executor = NaiveGraphExecutorAndWatcher()
         executor.exec(graph, token=token)
     else:
         raise NotImplementedError(

--- a/pipelime/pipes/communication.py
+++ b/pipelime/pipes/communication.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import time
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -200,8 +201,6 @@ class PiperCommunicationChannelFS(PiperCommunicationChannel):
         self._file.parent.mkdir(parents=True, exist_ok=True)
 
         self._rfd = None
-        with open(self._file, "ab"):
-            pass
 
         self._cbs = []
         self._stop_flag = False
@@ -244,6 +243,11 @@ class PiperCommunicationChannelFS(PiperCommunicationChannel):
         return True
 
     def listen(self) -> None:
+        self._file.parent.mkdir(parents=True, exist_ok=True)
+        self._file.unlink(missing_ok=True)
+        with open(self._file, "ab"):
+            pass
+
         while not self._stop_flag:
             data = self._try_read()
 

--- a/pipelime/pipes/executors/naive.py
+++ b/pipelime/pipes/executors/naive.py
@@ -252,5 +252,5 @@ class NaiveGraphExecutor(NodesGraphExecutor):
                         raise SampleSchema.ValidationError
 
                 else:
-                    logger.error(f"Node {str(node)} failed -> {stderr}")
-                    raise RuntimeError(f"{stderr}")
+                    logger.error(f"Node {str(node)} failed -> {stderr.decode()}")
+                    raise RuntimeError(f"{stderr.decode()}")

--- a/pipelime/pipes/executors/naive.py
+++ b/pipelime/pipes/executors/naive.py
@@ -1,17 +1,15 @@
-from multiprocessing import Process
-import os
-from pathlib import Path
 import subprocess
-from threading import Thread
+from pathlib import Path
 from typing import Any, Dict, List, Sequence, Tuple
+
+from loguru import logger
+
 from pipelime.pipes.executors.base import NodeModelExecutionParser, NodesGraphExecutor
-from pipelime.pipes.graph import GraphNodeOperation, DAGNodesGraph
+from pipelime.pipes.graph import DAGNodesGraph, GraphNodeOperation
 from pipelime.pipes.model import NodeModel
 from pipelime.pipes.piper import PiperNamespace
-from pipelime.pipes.watcher import Watcher
 from pipelime.sequences.readers.filesystem import UnderfolderReader
 from pipelime.sequences.validation import OperationValidate, SampleSchema, SchemaLoader
-from loguru import logger
 
 
 class NaiveNodeModelExecutionParser(NodeModelExecutionParser):
@@ -256,16 +254,3 @@ class NaiveGraphExecutor(NodesGraphExecutor):
                 else:
                     logger.error(f"Node {str(node)} failed -> {stderr}")
                     raise RuntimeError(f"{stderr}")
-
-
-class NaiveGraphExecutorAndWatcher(NaiveGraphExecutor):
-    def exec(self, graph: DAGNodesGraph, token: str = "") -> bool:
-        logger.remove()
-        watcher = Watcher(token)
-        watcher.watch()
-        res = False
-        try:
-            res = super().exec(graph, token)
-        finally:
-            watcher.stop()
-        return res

--- a/pipelime/pipes/locks.py
+++ b/pipelime/pipes/locks.py
@@ -1,0 +1,70 @@
+import os
+import time
+import errno
+
+
+class Lockfile(object):
+    """A file locking mechanism that has context-manager support so
+    you can use it in a with statement. This should be relatively cross
+    compatible as it doesn't rely on msvcrt or fcntl for the locking.
+    """
+
+    def __init__(self, lockfile, timeout=-1, delay=0.05):
+        """Prepare the file locker. Specify the file to lock and optionally
+        the maximum timeout and the delay between each attempt to lock.
+        """
+        self._is_locked = False
+        self._lockfile = lockfile
+        self._timeout = timeout
+        self._delay = delay
+
+    def acquire(self):
+        """Acquire the lock, if possible. If the lock is in use, it check again
+        every `wait` seconds. It does this until it either gets the lock or
+        exceeds `timeout` number of seconds, in which case it throws
+        an exception.
+        """
+        start_time = time.time()
+        while not self._is_locked:
+            try:
+                # Open file exclusively
+                self.fd = os.open(self.lockfile, os.O_CREAT | os.O_EXCL | os.O_RDWR)
+                self._is_locked = True
+            except OSError as e:
+                if e.errno != errno.EEXIST:
+                    raise
+                if self._timeout > 0 and (time.time() - start_time) >= self._timeout:
+                    raise IOError("Timeout occured.")
+                time.sleep(self._delay)
+
+    def release(self):
+        """Get rid of the lock by deleting the lockfile.
+        When working in a `with` statement, this gets automatically
+        called at the end.
+        """
+        # Close files, delete files
+        if self._is_locked:
+            os.close(self.fd)
+            os.unlink(self.lockfile)
+            self._is_locked = False
+
+    def __enter__(self):
+        """Activated when used in the with statement.
+        Should automatically acquire a lock to be used in the with block.
+        """
+        if not self._is_locked:
+            self.acquire()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        """Activated at the end of the with statement.
+        It automatically releases the lock if it isn't locked.
+        """
+        if self._is_locked:
+            self.release()
+
+    def __del__(self):
+        """Make sure that the FileLock instance doesn't leave a lockfile
+        lying around.
+        """
+        self.release()

--- a/pipelime/pipes/watcher.py
+++ b/pipelime/pipes/watcher.py
@@ -98,7 +98,6 @@ class Watcher:
             self._tasks_map[event][0] += 1
 
     def _listener_thread(self):
-        rich.print(f"Channel class: {self._channel.__class__}")
         self._channel.register_callback(self._callback)
         self._channel.listen()
 

--- a/pipelime/pipes/watcher.py
+++ b/pipelime/pipes/watcher.py
@@ -1,0 +1,124 @@
+import time
+from threading import Thread
+
+import numpy as np
+import rich
+from pydantic import BaseModel
+from rich.live import Live
+from rich.table import Table
+
+from pipelime.pipes.communication import PiperCommunicationChannelFactory
+
+
+class ChunkProgress(BaseModel):
+    id_: str
+    chunk_index: int
+    progress: float
+
+    @property
+    def file(self):
+        return self.id_.split(":")[0]
+
+    @property
+    def method(self):
+        return self.id_.split(":")[1]
+
+    @property
+    def unique(self):
+        return self.id_.split(":")[2]
+
+
+class Watcher:
+    def __init__(self, token: str) -> None:
+        self._tasks_map = {}
+        self._stop_flag = False
+
+        self._channel = PiperCommunicationChannelFactory.create_channel(token)
+
+        self._listener = None
+        self._printer = None
+
+    def _percentage_string(self, v: float):
+        colors = ["red", "yellow", "green"]
+        ths = np.linspace(0.0, 1.0, len(colors) + 1)[:-1]
+
+        color = colors[0]
+        for th, maybe_color in zip(ths, colors):
+            if v > th:
+                color = maybe_color
+
+        return f"[{color}]{v*100:.1f}%[/{color}]"
+
+    def _generate_table(self) -> Table:
+        """Make a new table."""
+        table = Table()
+        table.add_column("File")
+        table.add_column("Method")
+        table.add_column("ID")
+        table.add_column("Progress")
+
+        for task_id in self._tasks_map.keys():
+            progress = [
+                self._percentage_string(v) for v in self._tasks_map[task_id].values()
+            ]
+            progress = " ‖ ".join(progress)
+
+            filename, method, unique = task_id.split(":")
+            table.add_row(f"{filename}", f"{method}", f"{unique}", f"{progress}")
+
+        return table
+
+    def _callback(self, data: dict):
+        payload = data["payload"]
+        if "_progress" in payload:
+            progress = payload["_progress"]
+
+            chunk_progress = ChunkProgress(
+                id_=data["id"],
+                chunk_index=progress["chunk_index"],
+                progress=progress["progress_data"]["advance"]
+                / progress["progress_data"]["total"],
+            )
+
+            if chunk_progress.id_ not in self._tasks_map:
+                self._tasks_map[chunk_progress.id_] = {}
+            if chunk_progress.chunk_index not in self._tasks_map[chunk_progress.id_]:
+                self._tasks_map[chunk_progress.id_][chunk_progress.chunk_index] = 0.0
+
+            self._tasks_map[chunk_progress.id_][
+                chunk_progress.chunk_index
+            ] += chunk_progress.progress
+
+        elif "event" in payload:
+            event = payload["event"]
+
+            if event not in self._tasks_map:
+                self._tasks_map[event] = {0: 0.0}
+
+            self._tasks_map[event][0] += 1
+
+    def _listener_thread(self):
+        rich.print(f"Channel class: {self._channel.__class__}")
+        self._channel.register_callback(self._callback)
+        self._channel.listen()
+
+    def _printer_thread(self):
+        with Live(self._generate_table(), refresh_per_second=4) as live:
+            while not self._stop_flag:
+                time.sleep(0.1)
+                live.update(self._generate_table())
+
+        self._channel.close()
+
+    def stop(self) -> None:
+        self._stop_flag = True
+        self._listener.join()
+        self._printer.join()
+
+    def watch(self):
+        self._stop_flag = False
+        self._listener = Thread(target=self._listener_thread, daemon=True)
+        self._printer = Thread(target=self._printer_thread, daemon=True)
+
+        self._listener.start()
+        self._printer.start()

--- a/pipelime/tools/progress.py
+++ b/pipelime/tools/progress.py
@@ -1,15 +1,17 @@
-from typing import Callable, Iterable, List, Sequence, Optional, Any, Sized, Union
+import os
 import warnings
+from typing import Any, Callable, Iterable, List, Optional, Sequence, Sized, Union
+
 from rich.console import Console
 from rich.progress import (
+    BarColumn,
     Progress,
     ProgressColumn,
-    TextColumn,
-    BarColumn,
-    TimeRemainingColumn,
     ProgressType,
-    _TrackThread,
     TaskID,
+    TextColumn,
+    TimeRemainingColumn,
+    _TrackThread,
 )
 
 
@@ -159,11 +161,11 @@ def pipelime_track(
         Iterable[ProgressType]: An iterable of the values in the sequence.
 
     """
-
+    logo = " " if os.name == "nt" else "🍋"
     columns: List["ProgressColumn"] = (
-        [TextColumn("🍋|[progress.description]{task.description}")]
+        [TextColumn(logo + "|[progress.description]{task.description}")]
         if description
-        else [TextColumn("🍋|")]
+        else [TextColumn(logo + "|")]
     )
     columns.extend(
         (


### PR DESCRIPTION
Added:
- `Watcher` class that provides live rich table with piper progress update 
- `WatcherNodesGraphExecutor` wrapper that adds a watcher to a `NodesGraphExecutor` of any kind.
- `--watch` option to `pipelime piper execute` cli to activate watcher behavior.
- `PiperCommunicationChannelFS` that requires no backend, it works by reading/writing to a file protected by a mutex lock.

Changed:
- Pipelime default channel type is now `PiperCommunicationChannelFS`

Fixed:
- Removed 🍋 emojis on windows.
- Piper stderr is now decoded before printing - no more red WOTs when a node crashes. 